### PR TITLE
Fixed a bug after delete user from the application

### DIFF
--- a/ui/src/app/store/app-user/effects.ts
+++ b/ui/src/app/store/app-user/effects.ts
@@ -14,12 +14,14 @@
  * permissions and limitations under the License.
  */
 import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { of } from 'rxjs';
 import { catchError, map, switchMap, tap } from 'rxjs/operators';
 import { AppUserService } from 'src/app/core/app-user/app-user.service';
 import { SnackBarService } from 'src/app/features/snackbar/snackbar.service';
 
+import { Routes } from '../../data/enums/routers-url.enum';
 import { loadApplications } from '../application/action';
 import {
   addAppUserEntityAction,
@@ -37,7 +39,12 @@ import {
 
 @Injectable()
 export class AppUserEffects {
-  constructor(private actions: Actions, private appUserService: AppUserService, private snackBarService: SnackBarService) {}
+  constructor(
+    private actions: Actions,
+    private appUserService: AppUserService,
+    private snackBarService: SnackBarService,
+    private router: Router
+  ) {}
 
   @Effect()
   loadAppUsers = this.actions.pipe(
@@ -63,6 +70,7 @@ export class AppUserEffects {
     switchMap(action =>
       this.appUserService.deleteUser(action.applicationId, action.userId).pipe(
         map(() => deleteUserFromApplicationSuccess({ id: action.userId })),
+        tap(() => this.router.navigateByUrl(Routes.Home)),
         catchError(error => of(deleteUserFromApplicationFail({ error })))
       )
     )


### PR DESCRIPTION
_**Problem:**_
After deleting a user from the application we continue to stay in this application and can able to do any action as Org User/App Admin.

_**After this fix:**_
Now after deleting himself, the user will be redirected to the Home page, and no more see the application from which the user was deleted.
![Peek 2020-12-29 18-15](https://user-images.githubusercontent.com/26149983/103298014-2a008800-4a02-11eb-9f09-8e8fc6b17834.gif)
