### PR TITLE
EFRS-1090: No cache header in endpoint for retrieving images

### DIFF
--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/EmbeddingController.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/EmbeddingController.java
@@ -13,10 +13,12 @@ import com.exadel.frs.core.trainservice.service.SubjectService;
 import com.exadel.frs.core.trainservice.validation.ImageExtensionValidator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiParam;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -87,9 +89,10 @@ public class EmbeddingController {
 
     @GetMapping(value = "/{embeddingId}/img", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public @ResponseBody
-    byte[] downloadImg(
-            @ApiParam(value = API_KEY_DESC, required = true) @RequestHeader(name = X_FRS_API_KEY_HEADER) final String apiKey,
-            @ApiParam(value = IMAGE_ID_DESC, required = true) @PathVariable final UUID embeddingId) {
+    byte[] downloadImg(HttpServletResponse response,
+                       @ApiParam(value = API_KEY_DESC, required = true) @RequestHeader(name = X_FRS_API_KEY_HEADER) final String apiKey,
+                       @ApiParam(value = IMAGE_ID_DESC, required = true) @PathVariable final UUID embeddingId) {
+        response.addHeader(HttpHeaders.CACHE_CONTROL, CACHE_CONTROL_HEADER_VALUE);
         return embeddingService.getImg(apiKey, embeddingId)
                 .map(Img::getContent)
                 .orElse(new byte[]{});

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/StaticController.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/StaticController.java
@@ -3,7 +3,9 @@ package com.exadel.frs.core.trainservice.controller;
 import com.exadel.frs.commonservice.entity.Img;
 import com.exadel.frs.core.trainservice.service.EmbeddingService;
 import io.swagger.annotations.ApiParam;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,9 +22,10 @@ public class StaticController {
 
     @GetMapping(value = "/{apiKey}/images/{embeddingId}", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public @ResponseBody
-    byte[] downloadImg(
-            @ApiParam(value = API_KEY_DESC, required = true) @PathVariable("apiKey") final String apiKey,
-            @ApiParam(value = IMAGE_ID_DESC, required = true) @PathVariable final UUID embeddingId) {
+    byte[] downloadImg(HttpServletResponse response,
+                       @ApiParam(value = API_KEY_DESC, required = true) @PathVariable("apiKey") final String apiKey,
+                       @ApiParam(value = IMAGE_ID_DESC, required = true) @PathVariable final UUID embeddingId) {
+        response.addHeader(HttpHeaders.CACHE_CONTROL, CACHE_CONTROL_HEADER_VALUE);
         return embeddingService.getImg(apiKey, embeddingId)
                 .map(Img::getContent)
                 .orElse(new byte[]{});

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/system/global/Constants.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/system/global/Constants.java
@@ -58,4 +58,5 @@ public class Constants {
     public static final String DEMO_API_KEY = "00000000-0000-0000-0000-000000000002";
     public static final String FACENET2018 = "Facenet2018";
     public static final String SERVER_UUID = UUID.randomUUID().toString();
+    public static final String CACHE_CONTROL_HEADER_VALUE = "public, max-age=31536000";
 }


### PR DESCRIPTION
added cache control header to allow browser cache the images