### PR TITLE
EFRS-1051: Add 'Delete images in bulk' endpoint

### DIFF
--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/EmbeddingController.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/EmbeddingController.java
@@ -13,6 +13,7 @@ import com.exadel.frs.core.trainservice.service.SubjectService;
 import com.exadel.frs.core.trainservice.validation.ImageExtensionValidator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiParam;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.data.domain.Page;
@@ -23,7 +24,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotEmpty;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -121,6 +121,17 @@ public class EmbeddingController {
             @ApiParam(value = IMAGE_ID_DESC, required = true) @PathVariable final UUID embeddingId) {
         var embedding = subjectService.removeSubjectEmbedding(apiKey, embeddingId);
         return new EmbeddingDto(embeddingId.toString(), embedding.getSubject().getSubjectName());
+    }
+    @WriteEndpoint
+    @PostMapping("/delete")
+    public List<EmbeddingDto> deleteEmbeddingsById(
+            @ApiParam(value = API_KEY_DESC, required = true) @RequestHeader(name = X_FRS_API_KEY_HEADER) final String apiKey,
+            @ApiParam(value = IMAGE_IDS_DESC, required = true) @RequestBody List<UUID> embeddingIds) {
+        List<Embedding> list = subjectService.removeSubjectEmbeddings(apiKey, embeddingIds);
+        List<EmbeddingDto> dtoList = list.stream()
+                                         .map(c -> new EmbeddingDto(c.getId().toString(), c.getSubject().getSubjectName()))
+                                         .collect(Collectors.toList());
+        return dtoList;
     }
 
     @PostMapping(value = "/{embeddingId}/verify", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/service/SubjectService.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/service/SubjectService.java
@@ -2,6 +2,7 @@ package com.exadel.frs.core.trainservice.service;
 
 import com.exadel.frs.commonservice.entity.Embedding;
 import com.exadel.frs.commonservice.entity.Subject;
+import com.exadel.frs.commonservice.exception.EmbeddingNotFoundException;
 import com.exadel.frs.commonservice.exception.TooManyFacesException;
 import com.exadel.frs.commonservice.sdk.faces.FacesApiClient;
 import com.exadel.frs.commonservice.sdk.faces.feign.dto.FindFacesResponse;
@@ -15,6 +16,7 @@ import com.exadel.frs.core.trainservice.dto.EmbeddingInfo;
 import com.exadel.frs.core.trainservice.dto.FaceVerification;
 import com.exadel.frs.core.trainservice.dto.ProcessImageParams;
 import com.exadel.frs.core.trainservice.system.global.Constants;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -109,6 +111,17 @@ public class SubjectService {
         );
 
         return embedding;
+    }
+    public List<Embedding> removeSubjectEmbeddings(final String apiKey, final List<UUID> embeddingIds){
+        List<Embedding> result = new ArrayList<>();
+        for (UUID id: embeddingIds) {
+            try {
+                result.add(removeSubjectEmbedding(apiKey, id));
+            } catch (EmbeddingNotFoundException e){
+                e.printStackTrace();
+            }
+        }
+        return result;
     }
 
     public boolean updateSubjectName(final String apiKey, final String oldSubjectName, final String newSubjectName) {

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/system/global/Constants.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/system/global/Constants.java
@@ -47,6 +47,7 @@ public class Constants {
     public static final String LIMIT_DEFAULT_VALUE = "0";
     public static final String IMAGE_WITH_ONE_FACE_DESC = "A picture with one face (accepted formats: jpeg, png).";
     public static final String IMAGE_ID_DESC = "Image Id from collection to compare with face.";
+    public static final String IMAGE_IDS_DESC = "List of image Ids from collection to compare with face";
     public static final String SUBJECT_DESC = "Person's name to whom the face belongs to.";
     public static final String SUBJECT = "subject";
     public static final String SUBJECTS = "faces";


### PR DESCRIPTION
added "/delete" endpoint (post) to allow bulk delete list of image examples by IDs