### PR TITLE
Adjust validation for subject name - do not allow null value and empty value

### DIFF
--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/EmbeddingController.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/EmbeddingController.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -36,6 +37,7 @@ import static com.exadel.frs.commonservice.system.global.Constants.DET_PROB_THRE
 import static com.exadel.frs.core.trainservice.system.global.Constants.*;
 import static org.springframework.http.HttpStatus.CREATED;
 
+@Validated
 @RestController
 @RequestMapping(API_V1 + "/recognition/faces")
 @RequiredArgsConstructor

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/EmbeddingController.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/EmbeddingController.java
@@ -54,7 +54,7 @@ public class EmbeddingController {
     @PostMapping
     public EmbeddingDto addEmbedding(
             @ApiParam(value = IMAGE_WITH_ONE_FACE_DESC, required = true) @RequestParam final MultipartFile file,
-            @ApiParam(value = SUBJECT_DESC, required = true) @Valid @NotBlank(message = "Subject name is empty") @RequestParam(SUBJECT) final String subjectName,
+            @ApiParam(value = SUBJECT_DESC, required = true) @Valid @NotBlank(message = SUBJECT_NAME_IS_EMPTY) @RequestParam(SUBJECT) final String subjectName,
             @ApiParam(value = DET_PROB_THRESHOLD_DESC) @RequestParam(value = DET_PROB_THRESHOLD, required = false) final Double detProbThreshold,
             @ApiParam(value = API_KEY_DESC, required = true) @RequestHeader(X_FRS_API_KEY_HEADER) final String apiKey
     ) throws IOException {
@@ -75,7 +75,7 @@ public class EmbeddingController {
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     public EmbeddingDto addEmbeddingBase64(
             @ApiParam(value = API_KEY_DESC, required = true) @RequestHeader(X_FRS_API_KEY_HEADER) final String apiKey,
-            @ApiParam(value = SUBJECT_DESC) @Valid @NotBlank(message = "Subject name is empty") @RequestParam(value = SUBJECT) String subjectName,
+            @ApiParam(value = SUBJECT_DESC) @Valid @NotBlank(message = SUBJECT_NAME_IS_EMPTY) @RequestParam(value = SUBJECT) String subjectName,
             @ApiParam(value = DET_PROB_THRESHOLD_DESC) @RequestParam(value = DET_PROB_THRESHOLD, required = false) final Double detProbThreshold,
             @Valid @RequestBody Base64File request) {
         imageValidator.validateBase64(request.getContent());
@@ -112,7 +112,7 @@ public class EmbeddingController {
     @DeleteMapping
     public Map<String, Object> removeAllSubjectEmbeddings(
             @ApiParam(value = API_KEY_DESC, required = true) @RequestHeader(name = X_FRS_API_KEY_HEADER) final String apiKey,
-            @ApiParam(value = SUBJECT_DESC) @Valid @NotBlank(message = "Subject name is empty") @RequestParam( name = SUBJECT, required = false) final String subjectName
+            @ApiParam(value = SUBJECT_DESC) @Validated @NotBlank(message = SUBJECT_NAME_IS_EMPTY) @RequestParam( name = SUBJECT, required = false) final String subjectName
     ) {
         return Map.of(
                 "deleted",

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/EmbeddingController.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/EmbeddingController.java
@@ -26,6 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +52,7 @@ public class EmbeddingController {
     @PostMapping
     public EmbeddingDto addEmbedding(
             @ApiParam(value = IMAGE_WITH_ONE_FACE_DESC, required = true) @RequestParam final MultipartFile file,
-            @ApiParam(value = SUBJECT_DESC, required = true) @RequestParam(SUBJECT) final String subjectName,
+            @ApiParam(value = SUBJECT_DESC, required = true) @Valid @NotBlank(message = "Subject name is empty") @RequestParam(SUBJECT) final String subjectName,
             @ApiParam(value = DET_PROB_THRESHOLD_DESC) @RequestParam(value = DET_PROB_THRESHOLD, required = false) final Double detProbThreshold,
             @ApiParam(value = API_KEY_DESC, required = true) @RequestHeader(X_FRS_API_KEY_HEADER) final String apiKey
     ) throws IOException {
@@ -72,7 +73,7 @@ public class EmbeddingController {
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     public EmbeddingDto addEmbeddingBase64(
             @ApiParam(value = API_KEY_DESC, required = true) @RequestHeader(X_FRS_API_KEY_HEADER) final String apiKey,
-            @ApiParam(value = SUBJECT_DESC) @RequestParam(value = SUBJECT) String subjectName,
+            @ApiParam(value = SUBJECT_DESC) @Valid @NotBlank(message = "Subject name is empty") @RequestParam(value = SUBJECT) String subjectName,
             @ApiParam(value = DET_PROB_THRESHOLD_DESC) @RequestParam(value = DET_PROB_THRESHOLD, required = false) final Double detProbThreshold,
             @Valid @RequestBody Base64File request) {
         imageValidator.validateBase64(request.getContent());
@@ -109,7 +110,7 @@ public class EmbeddingController {
     @DeleteMapping
     public Map<String, Object> removeAllSubjectEmbeddings(
             @ApiParam(value = API_KEY_DESC, required = true) @RequestHeader(name = X_FRS_API_KEY_HEADER) final String apiKey,
-            @ApiParam(value = SUBJECT_DESC) @RequestParam( name = SUBJECT, required = false) final String subjectName
+            @ApiParam(value = SUBJECT_DESC) @Valid @NotBlank(message = "Subject name is empty") @RequestParam( name = SUBJECT, required = false) final String subjectName
     ) {
         return Map.of(
                 "deleted",

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/SubjectController.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/SubjectController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import java.util.Map;
 
 import static com.exadel.frs.core.trainservice.system.global.Constants.*;
@@ -41,7 +42,7 @@ public class SubjectController {
     @PutMapping("/{subject}")
     public Map<String, Object> renameSubject(
             @ApiParam(value = API_KEY_DESC, required = true) @RequestHeader(X_FRS_API_KEY_HEADER) final String apiKey,
-            @ApiParam(value = SUBJECT_DESC, required = true) @PathVariable("subject") final String oldSubjectName,
+            @ApiParam(value = SUBJECT_DESC, required = true) @Valid @NotBlank(message = "Subject name is empty") @PathVariable("subject") final String oldSubjectName,
             @Valid @RequestBody final SubjectDto subjectDto) {
         return Map.of(
                 "updated",
@@ -52,7 +53,7 @@ public class SubjectController {
     @DeleteMapping("/{subject}")
     public Map<String, Object> deleteSubject(
             @ApiParam(value = API_KEY_DESC, required = true) @RequestHeader(X_FRS_API_KEY_HEADER) final String apiKey,
-            @ApiParam(value = SUBJECT_DESC, required = true) @PathVariable("subject") final String subjectName) {
+            @ApiParam(value = SUBJECT_DESC, required = true) @Valid @NotBlank(message = "Subject name is empty") @PathVariable("subject") final String subjectName) {
         return Map.of(
                 "subject",
                 subjectService.deleteSubjectByName(apiKey, subjectName)

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/SubjectController.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/SubjectController.java
@@ -44,7 +44,7 @@ public class SubjectController {
     @PutMapping("/{subject}")
     public Map<String, Object> renameSubject(
             @ApiParam(value = API_KEY_DESC, required = true) @RequestHeader(X_FRS_API_KEY_HEADER) final String apiKey,
-            @ApiParam(value = SUBJECT_DESC, required = true) @Valid @NotBlank(message = "Subject name is empty") @PathVariable("subject") final String oldSubjectName,
+            @ApiParam(value = SUBJECT_DESC, required = true) @Valid @NotBlank(message = SUBJECT_NAME_IS_EMPTY) @PathVariable("subject") final String oldSubjectName,
             @Valid @RequestBody final SubjectDto subjectDto) {
         return Map.of(
                 "updated",
@@ -55,7 +55,7 @@ public class SubjectController {
     @DeleteMapping("/{subject}")
     public Map<String, Object> deleteSubject(
             @ApiParam(value = API_KEY_DESC, required = true) @RequestHeader(X_FRS_API_KEY_HEADER) final String apiKey,
-            @ApiParam(value = SUBJECT_DESC, required = true) @Valid @NotBlank(message = "Subject name is empty") @PathVariable("subject") final String subjectName) {
+            @ApiParam(value = SUBJECT_DESC, required = true) @Valid @NotBlank(message = SUBJECT_NAME_IS_EMPTY) @PathVariable("subject") final String subjectName) {
         return Map.of(
                 "subject",
                 subjectService.deleteSubjectByName(apiKey, subjectName)

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/SubjectController.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/SubjectController.java
@@ -5,6 +5,7 @@ import com.exadel.frs.core.trainservice.dto.SubjectDto;
 import com.exadel.frs.core.trainservice.service.SubjectService;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -14,6 +15,7 @@ import java.util.Map;
 import static com.exadel.frs.core.trainservice.system.global.Constants.*;
 import static org.springframework.http.HttpStatus.CREATED;
 
+@Validated
 @RestController
 @RequestMapping(API_V1 + "/recognition/subjects")
 @RequiredArgsConstructor

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/dto/SubjectDto.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/dto/SubjectDto.java
@@ -6,7 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 
 import static com.exadel.frs.core.trainservice.system.global.Constants.SUBJECT_DESC;
 
@@ -17,6 +17,6 @@ public class SubjectDto {
 
     @ApiParam(value = SUBJECT_DESC, required = true)
     @JsonProperty("subject")
-    @NotNull
+    @NotBlank(message = "Subject name is empty")
     private String subjectName;
 }

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/system/global/Constants.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/system/global/Constants.java
@@ -55,6 +55,7 @@ public class Constants {
     public static final String SOURCE_IMAGE_DESC = "File to be verified";
     public static final String TARGET_IMAGE_DESC = "Reference file to check the processed file";
     public static final String STATUS = "status";
+    public static final String SUBJECT_NAME_IS_EMPTY = "Subject name is empty";
 
     public static final String DEMO_API_KEY = "00000000-0000-0000-0000-000000000002";
     public static final String FACENET2018 = "Facenet2018";


### PR DESCRIPTION
Adjusted validation in three places:
- `EmbeddingController`
- `SubjectController`
- `SubjectDto`

Replaced NotNull with NotBlank annotation (which checks it the value is the null or empty)

Performed some manual tests to check behaviour after fix.

Closes: #617 