### PR TITLE
EFSR-1096 - Incorrect text for error message when entered old password is less than 8 chars

### DIFF
--- a/java/admin/src/main/java/com/exadel/frs/dto/ui/ChangePasswordDto.java
+++ b/java/admin/src/main/java/com/exadel/frs/dto/ui/ChangePasswordDto.java
@@ -27,8 +27,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ChangePasswordDto {
 
-    @NotEmpty(message = "User's old password is incorrect")
-    @Size(min = 8, max = 255, message = "User's old password is incorrect")
+    @NotEmpty(message = "User's password is incorrect")
+    @Size(min = 8, max = 255, message = "User's password is incorrect")
     private String oldPassword;
 
     @NotEmpty(message = "User's new password is incorrect")


### PR DESCRIPTION
I have read the CLA Document and I hereby sign the CLA