### PR TITLE
EFSR-1136 - Api-key is displayed instead of application name when trying to add user that already exists in application

### DIFF
--- a/java/admin/src/main/java/com/exadel/frs/exception/UserAlreadyHasAccessToAppException.java
+++ b/java/admin/src/main/java/com/exadel/frs/exception/UserAlreadyHasAccessToAppException.java
@@ -25,7 +25,7 @@ public class UserAlreadyHasAccessToAppException extends BasicException {
 
     private static final String MESSAGE = "User %s already has access to application %s";
 
-    public UserAlreadyHasAccessToAppException(String user, String appGuid) {
-        super(USER_ALREADY_HAS_ACCESS_TO_APP, format(MESSAGE, user, appGuid));
+    public UserAlreadyHasAccessToAppException(String user, String appName) {
+        super(USER_ALREADY_HAS_ACCESS_TO_APP, format(MESSAGE, user, appName));
     }
 }

--- a/java/admin/src/main/java/com/exadel/frs/service/AppService.java
+++ b/java/admin/src/main/java/com/exadel/frs/service/AppService.java
@@ -154,7 +154,7 @@ public class AppService {
 
         val userAppRole = app.getUserAppRole(user.getId());
         if (userAppRole.isPresent()) {
-            throw new UserAlreadyHasAccessToAppException(userInviteDto.getUserEmail(), appGuid);
+            throw new UserAlreadyHasAccessToAppException(userInviteDto.getUserEmail(), app.getName());
         }
 
         val appRole = AppRole.valueOf(userInviteDto.getRole());


### PR DESCRIPTION
I have read the CLA Document and I hereby sign the CLA