### PR TITLE
Fix nginx /admin/ location for 1.1.x

### DIFF
--- a/dev/nginx/conf.d/nginx.conf
+++ b/dev/nginx/conf.d/nginx.conf
@@ -31,7 +31,7 @@ server {
     }
 
     location /admin/ {
-        proxy_pass http://frsadmin/admin/;
+        proxy_pass http://frsadmin/;
     }
 
     location /api/v1/ {


### PR DESCRIPTION
Based on differences between master and 1.1.x we need to use old proxy pass for /admin location in 1.1.x branch nginx config 