### PR TITLE
 EFRS-1278: Add ability to skip face detection step + Java PR

### DIFF
--- a/embedding-calculator/src/_endpoints.py
+++ b/embedding-calculator/src/_endpoints.py
@@ -26,6 +26,7 @@ from src.services.flask_.needs_attached_file import needs_attached_file
 from src.services.imgtools.read_img import read_img
 from src.services.utils.pyutils import Constants
 import base64
+from src.services.facescan.plugins.facenet.facenet import FaceDetection
 
 
 def endpoints(app):
@@ -48,6 +49,8 @@ def endpoints(app):
             _get_face_plugin_names()
         )
 
+        if request.values.get("detect_faces") == "false":
+            FaceDetection.skippingFaceDetection = True
         rawfile = base64.b64decode(request.get_json()["file"])
 
         faces = detector(
@@ -63,6 +66,9 @@ def endpoints(app):
     @needs_attached_file
     def find_faces_post():
         detector = managers.plugin_manager.detector
+
+        if request.values.get("detect_faces") == "false":
+            FaceDetection.skippingFaceDetection = True
         face_plugins = managers.plugin_manager.filter_face_plugins(
             _get_face_plugin_names()
         )

--- a/embedding-calculator/src/constants.py
+++ b/embedding-calculator/src/constants.py
@@ -39,3 +39,4 @@ class ENV(Constants):
 
 LOGGING_LEVEL = logging._nameToLevel[ENV.LOGGING_LEVEL_NAME]
 ENV_MAIN = ENV
+SKIPPED_PLUGINS = ["insightface.PoseEstimator", "facemask.MaskDetector", "facenet.PoseEstimator"]

--- a/embedding-calculator/src/services/facescan/plugins/facenet/facenet.py
+++ b/embedding-calculator/src/services/facescan/plugins/facenet/facenet.py
@@ -32,16 +32,13 @@ from src.services.imgtools.types import Array3D
 from src.services.utils.pyutils import get_current_dir
 
 from src.services.facescan.plugins import base
+from src._endpoints import FaceDetection
 
 CURRENT_DIR = get_current_dir(__file__)
 
 logger = logging.getLogger(__name__)
 _EmbeddingCalculator = namedtuple('_EmbeddingCalculator', 'graph sess')
 _FaceDetectionNets = namedtuple('_FaceDetectionNets', 'pnet rnet onet')
-
-
-class FaceDetection(object):
-    skippingFaceDetection = False
 
 
 def prewhiten(img):
@@ -90,9 +87,9 @@ class FaceDetector(mixins.FaceDetectorMixin, base.BasePlugin):
         scaler = ImgScaler(self.IMG_LENGTH_LIMIT)
         img = scaler.downscale_img(img)
 
-        if FaceDetection.skippingFaceDetection:
+        if FaceDetection.SKIPPING_FACE_DETECTION:
             bounding_boxes = []
-            detect_face_result = bounding_boxes.append({
+            bounding_boxes.append({
                 'box': [0, 0, img.shape[0], img.shape[1]],
                 'confidence': 0.99,
                 'keypoints': {
@@ -103,6 +100,7 @@ class FaceDetector(mixins.FaceDetectorMixin, base.BasePlugin):
                     'mouth_right': (),
                 }
             })
+            detect_face_result = bounding_boxes
         else:
             fdn = self._face_detection_net
             detect_face_result = fdn.detect_faces(img)
@@ -130,7 +128,6 @@ class FaceDetector(mixins.FaceDetectorMixin, base.BasePlugin):
                 logger.debug(f'Box filtered out because below threshold ({det_prob_threshold}): {box}')
                 continue
             filtered_bounding_boxes.append(box)
-        FaceDetection.skippingFaceDetection = False
         return filtered_bounding_boxes
 
 

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/component/migration/MigrationComponent.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/component/migration/MigrationComponent.java
@@ -87,7 +87,8 @@ public class MigrationComponent {
                     new MultipartFileData(content, "recalculated", null),
                     1,
                     null,
-                    CALCULATOR_PLUGIN
+                    CALCULATOR_PLUGIN,
+                    true
             );
 
             return findFacesResponse.getResult().stream()

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/RecognizeController.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/controller/RecognizeController.java
@@ -19,6 +19,9 @@ package com.exadel.frs.core.trainservice.controller;
 import static com.exadel.frs.commonservice.system.global.Constants.DET_PROB_THRESHOLD;
 import static com.exadel.frs.core.trainservice.system.global.Constants.API_KEY_DESC;
 import static com.exadel.frs.core.trainservice.system.global.Constants.API_V1;
+import static com.exadel.frs.core.trainservice.system.global.Constants.DETECT_FACES;
+import static com.exadel.frs.core.trainservice.system.global.Constants.DETECT_FACES_DEFAULT_VALUE;
+import static com.exadel.frs.core.trainservice.system.global.Constants.DETECT_FACES_DESC;
 import static com.exadel.frs.core.trainservice.system.global.Constants.DET_PROB_THRESHOLD_DESC;
 import static com.exadel.frs.core.trainservice.system.global.Constants.FACE_PLUGINS;
 import static com.exadel.frs.core.trainservice.system.global.Constants.FACE_PLUGINS_DESC;
@@ -90,7 +93,10 @@ public class RecognizeController {
             final String facePlugins,
             @ApiParam(value = STATUS_DESC)
             @RequestParam(value = STATUS, required = false, defaultValue = STATUS_DEFAULT_VALUE)
-            final Boolean status
+            final Boolean status,
+            @ApiParam(value = DETECT_FACES_DESC)
+            @RequestParam(value = DETECT_FACES, required = false, defaultValue = DETECT_FACES_DEFAULT_VALUE)
+            final Boolean detectFaces
     ) {
         ProcessImageParams processImageParams = ProcessImageParams
                 .builder()
@@ -100,6 +106,7 @@ public class RecognizeController {
                 .detProbThreshold(detProbThreshold)
                 .facePlugins(facePlugins)
                 .status(status)
+                .detectFaces(detectFaces)
                 .additionalParams(Collections.singletonMap(PREDICTION_COUNT, predictionCount))
                 .build();
 
@@ -124,6 +131,9 @@ public class RecognizeController {
             @ApiParam(value = STATUS_DESC)
             @RequestParam(value = STATUS, required = false, defaultValue = STATUS_DEFAULT_VALUE)
             final Boolean status,
+            @ApiParam(value = DETECT_FACES_DESC)
+            @RequestParam(value = DETECT_FACES, required = false, defaultValue = DETECT_FACES_DEFAULT_VALUE)
+            final Boolean detectFaces,
             @ApiParam(value = PREDICTION_COUNT_DESC, example = NUMBER_VALUE_EXAMPLE)
             @RequestParam(value = PREDICTION_COUNT_REQUEST_PARAM, required = false, defaultValue = PREDICTION_COUNT_DEFAULT_VALUE)
             @Min(value = 1, message = PREDICTION_COUNT_MIN_DESC)
@@ -140,6 +150,7 @@ public class RecognizeController {
                 .detProbThreshold(detProbThreshold)
                 .facePlugins(facePlugins)
                 .status(status)
+                .detectFaces(detectFaces)
                 .additionalParams(Collections.singletonMap(PREDICTION_COUNT, predictionCount))
                 .build();
 

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/dto/ProcessImageParams.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/dto/ProcessImageParams.java
@@ -15,5 +15,6 @@ public class ProcessImageParams {
     private Double detProbThreshold;
     private String facePlugins;
     private Boolean status;
+    private Boolean detectFaces;
     private Map<String, Object> additionalParams;
 }

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/service/FaceDetectionProcessServiceImpl.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/service/FaceDetectionProcessServiceImpl.java
@@ -28,10 +28,10 @@ public class FaceDetectionProcessServiceImpl implements FaceProcessService {
         if (processImageParams.getFile() != null) {
             MultipartFile file = (MultipartFile) processImageParams.getFile();
             imageExtensionValidator.validate(file);
-            findFacesResponse = facesApiClient.findFaces(file, limit, detProbThreshold, facePlugins);
+            findFacesResponse = facesApiClient.findFaces(file, limit, detProbThreshold, facePlugins, true);
         } else {
             imageExtensionValidator.validateBase64(processImageParams.getImageBase64());
-            findFacesResponse = facesApiClient.findFacesBase64(processImageParams.getImageBase64(), limit, detProbThreshold, facePlugins);
+            findFacesResponse = facesApiClient.findFacesBase64(processImageParams.getImageBase64(), limit, detProbThreshold, facePlugins,true);
         }
 
         FacesDetectionResponseDto facesDetectionResponseDto = facesMapper.toFacesDetectionResponseDto(findFacesResponse);

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/service/FaceRecognizeProcessServiceImpl.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/service/FaceRecognizeProcessServiceImpl.java
@@ -44,10 +44,22 @@ public class FaceRecognizeProcessServiceImpl implements FaceProcessService {
         if (processImageParams.getFile() != null) {
             MultipartFile file = (MultipartFile) processImageParams.getFile();
             imageExtensionValidator.validate(file);
-            findFacesResponse = facesApiClient.findFacesWithCalculator(file, processImageParams.getLimit(), processImageParams.getDetProbThreshold(), processImageParams.getFacePlugins());
+            findFacesResponse = facesApiClient.findFacesWithCalculator(
+                    file,
+                    processImageParams.getLimit(),
+                    processImageParams.getDetProbThreshold(),
+                    processImageParams.getFacePlugins(),
+                    processImageParams.getDetectFaces()
+            );
         } else {
             imageExtensionValidator.validateBase64(processImageParams.getImageBase64());
-            findFacesResponse = facesApiClient.findFacesBase64WithCalculator(processImageParams.getImageBase64(), processImageParams.getLimit(), processImageParams.getDetProbThreshold(), processImageParams.getFacePlugins());
+            findFacesResponse = facesApiClient.findFacesBase64WithCalculator(
+                    processImageParams.getImageBase64(),
+                    processImageParams.getLimit(),
+                    processImageParams.getDetProbThreshold(),
+                    processImageParams.getFacePlugins(),
+                    processImageParams.getDetectFaces()
+            );
         }
 
         val facesRecognitionDto = facesMapper.toFacesRecognitionResponseDto(findFacesResponse);

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/service/FaceVerificationProcessServiceImpl.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/service/FaceVerificationProcessServiceImpl.java
@@ -91,7 +91,8 @@ public class FaceVerificationProcessServiceImpl implements FaceProcessService {
                     photo,
                     processImageParams.getLimit(),
                     processImageParams.getDetProbThreshold(),
-                    processImageParams.getFacePlugins()
+                    processImageParams.getFacePlugins(),
+                    true
             );
         }
     }
@@ -113,7 +114,8 @@ public class FaceVerificationProcessServiceImpl implements FaceProcessService {
                     photo,
                     processImageParams.getLimit(),
                     processImageParams.getDetProbThreshold(),
-                    processImageParams.getFacePlugins()
+                    processImageParams.getFacePlugins(),
+                    true
             );
         }
     }

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/service/SubjectService.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/service/SubjectService.java
@@ -160,7 +160,8 @@ public class SubjectService {
                 base64photo,
                 MAX_FACES_TO_RECOGNIZE,
                 detProbThreshold,
-                null
+                null,
+                true
         );
 
         return saveCalculatedEmbedding(
@@ -181,7 +182,8 @@ public class SubjectService {
                 file,
                 MAX_FACES_TO_RECOGNIZE,
                 detProbThreshold,
-                null
+                null,
+                true
         );
 
         return saveCalculatedEmbedding(
@@ -227,9 +229,11 @@ public class SubjectService {
         FindFacesResponse findFacesResponse;
         if (processImageParams.getFile() != null) {
             MultipartFile file = (MultipartFile) processImageParams.getFile();
-            findFacesResponse = facesApiClient.findFacesWithCalculator(file, processImageParams.getLimit(), processImageParams.getDetProbThreshold(), processImageParams.getFacePlugins());
+            findFacesResponse = facesApiClient.findFacesWithCalculator(file, processImageParams.getLimit(),
+                    processImageParams.getDetProbThreshold(), processImageParams.getFacePlugins(), true);
         } else {
-            findFacesResponse = facesApiClient.findFacesBase64WithCalculator(processImageParams.getImageBase64(), processImageParams.getLimit(), processImageParams.getDetProbThreshold(), processImageParams.getFacePlugins());
+            findFacesResponse = facesApiClient.findFacesBase64WithCalculator(processImageParams.getImageBase64(),
+                    processImageParams.getLimit(), processImageParams.getDetProbThreshold(), processImageParams.getFacePlugins(), true);
         }
 
         if (findFacesResponse == null) {

--- a/java/api/src/main/java/com/exadel/frs/core/trainservice/system/global/Constants.java
+++ b/java/api/src/main/java/com/exadel/frs/core/trainservice/system/global/Constants.java
@@ -41,8 +41,10 @@ public class Constants {
     public static final String DET_PROB_THRESHOLD_DESC = "The minimal percent confidence that found face is actually a face.";
     public static final String FACE_PLUGINS_DESC = "Comma-separated types of face plugins. Empty value - face plugins disabled, returns only bounding boxes";
     public static final String STATUS_DESC = "Special parameter to show execution_time and plugin_version fields. Empty value - both fields eliminated, true - both fields included";
+    public static final String DETECT_FACES_DESC = "The parameter specifies whether to perform image detection or not";
     public static final String PREDICTION_COUNT = "predictionCount";
     public static final String STATUS_DEFAULT_VALUE = "false";
+    public static final String DETECT_FACES_DEFAULT_VALUE = "true";
     public static final String PREDICTION_COUNT_DEFAULT_VALUE = "1";
     public static final String LIMIT_DEFAULT_VALUE = "0";
     public static final String IMAGE_WITH_ONE_FACE_DESC = "A picture with one face (accepted formats: jpeg, png).";
@@ -54,6 +56,7 @@ public class Constants {
     public static final String SOURCE_IMAGE_DESC = "File to be verified";
     public static final String TARGET_IMAGE_DESC = "Reference file to check the processed file";
     public static final String STATUS = "status";
+    public static final String DETECT_FACES = "detect_faces";
     public static final String SUBJECT_NAME_IS_EMPTY = "Subject name is empty";
 
     public static final String NUMBER_VALUE_EXAMPLE = "1";

--- a/java/api/src/test/java/com/exadel/frs/core/trainservice/component/migration/MigrationComponentTest.java
+++ b/java/api/src/test/java/com/exadel/frs/core/trainservice/component/migration/MigrationComponentTest.java
@@ -42,7 +42,7 @@ class MigrationComponentTest extends EmbeddedPostgreSQLTest {
 
         when(feignClient.getStatus())
                 .thenReturn(new FacesStatusResponse().setCalculatorVersion(currentCalculator));
-        when(feignClient.findFaces(any(), any(), any(), any()))
+        when(feignClient.findFaces(any(), any(), any(), any(), any()))
                 .thenReturn(FindFacesResponse.builder()
                         .result(List.of(FindFacesResult.builder().embedding(newEmbeddingArray).build()))
                         .build());

--- a/java/api/src/test/java/com/exadel/frs/core/trainservice/controller/DetectionControllerTest.java
+++ b/java/api/src/test/java/com/exadel/frs/core/trainservice/controller/DetectionControllerTest.java
@@ -102,7 +102,7 @@ class DetectionControllerTest extends EmbeddedPostgreSQLTest {
         String fileName = "file";
         val mockFile = new MockMultipartFile(fileName, "test data".getBytes());
         doNothing().when(validator).validate(mockFile);
-        when(client.findFaces(any(), any(), any(), any())).thenThrow(exception);
+        when(client.findFaces(any(), any(), any(), any(), any())).thenThrow(exception);
 
         // when
         mockMvc.perform(
@@ -122,7 +122,7 @@ class DetectionControllerTest extends EmbeddedPostgreSQLTest {
         val mockFile = new MockMultipartFile(fileName, "test data".getBytes());
         val findResponse = new FindFacesResponse();
         doNothing().when(validator).validate(mockFile);
-        when(client.findFaces(any(), any(), any(), any())).thenReturn(findResponse);
+        when(client.findFaces(any(), any(), any(), any(), any())).thenReturn(findResponse);
 
         // when
         mockMvc.perform(
@@ -139,7 +139,7 @@ class DetectionControllerTest extends EmbeddedPostgreSQLTest {
         // given
         val findResponse = new FindFacesResponse();
         doNothing().when(validator).validateBase64(any());
-        when(client.findFacesBase64(any(), any(), any(), any())).thenReturn(findResponse);
+        when(client.findFacesBase64(any(), any(), any(), any(), any())).thenReturn(findResponse);
 
         Base64File request = new Base64File();
         request.setContent(Base64.getEncoder().encodeToString(new byte[]{(byte) 0xCA}));

--- a/java/api/src/test/java/com/exadel/frs/core/trainservice/controller/RecognizeControllerTest.java
+++ b/java/api/src/test/java/com/exadel/frs/core/trainservice/controller/RecognizeControllerTest.java
@@ -85,7 +85,7 @@ class RecognizeControllerTest extends EmbeddedPostgreSQLTest {
                 ))
                 .build();
 
-        when(client.findFacesWithCalculator(any(), any(), any(), isNull())).thenReturn(findFacesResponse);
+        when(client.findFacesWithCalculator(any(), any(), any(), isNull(), any())).thenReturn(findFacesResponse);
         when(predictor.predict(any(), any(), anyInt())).thenReturn(List.of(Pair.of(1.0, "")));
         doNothing().when(validator).validate(mockFile);
 
@@ -106,7 +106,7 @@ class RecognizeControllerTest extends EmbeddedPostgreSQLTest {
                 ))
                 .build();
 
-        when(client.findFacesBase64WithCalculator(any(), any(), any(), isNull())).thenReturn(findFacesResponse);
+        when(client.findFacesBase64WithCalculator(any(), any(), any(), isNull(), any())).thenReturn(findFacesResponse);
         when(predictor.predict(any(), any(), anyInt())).thenReturn(List.of(Pair.of(1.0, "")));
         doNothing().when(validator).validateBase64(any());
 

--- a/java/api/src/test/java/com/exadel/frs/core/trainservice/controller/VerifyControllerTest.java
+++ b/java/api/src/test/java/com/exadel/frs/core/trainservice/controller/VerifyControllerTest.java
@@ -64,7 +64,7 @@ class VerifyControllerTest extends EmbeddedPostgreSQLTest {
                 ))
                 .build();
 
-        when(client.findFacesWithCalculator(any(), any(), any(), isNull())).thenReturn(findFacesResponse);
+        when(client.findFacesWithCalculator(any(), any(), any(), isNull(), any())).thenReturn(findFacesResponse);
         when(predictor.verify(any(), any())).thenReturn(new double[]{100d});
 
         val firstFile = new MockMultipartFile("source_image", "test data".getBytes());
@@ -78,7 +78,7 @@ class VerifyControllerTest extends EmbeddedPostgreSQLTest {
         ).andExpect(status().isOk());
 
         verify(validator, times(2)).validate(any());
-        verify(client, times(2)).findFacesWithCalculator(any(), any(), any(), isNull());
+        verify(client, times(2)).findFacesWithCalculator(any(), any(), any(), isNull(), any());
         verify(predictor).verify(any(), any(double[][].class));
         verifyNoMoreInteractions(validator, client, predictor);
     }
@@ -93,7 +93,7 @@ class VerifyControllerTest extends EmbeddedPostgreSQLTest {
                 ))
                 .build();
 
-        when(client.findFacesBase64WithCalculator(any(), any(), any(), anyString())).thenReturn(findFacesResponse);
+        when(client.findFacesBase64WithCalculator(any(), any(), any(), anyString(), any())).thenReturn(findFacesResponse);
         when(predictor.verify(any(), any())).thenReturn(new double[]{100d});
 
         VerifySourceTargetRequest request = new VerifySourceTargetRequest();
@@ -110,7 +110,7 @@ class VerifyControllerTest extends EmbeddedPostgreSQLTest {
         ).andExpect(status().isOk());
 
         verify(validator, times(2)).validateBase64(any());
-        verify(client, times(2)).findFacesBase64WithCalculator(any(), any(), any(), anyString());
+        verify(client, times(2)).findFacesBase64WithCalculator(any(), any(), any(), anyString(), any());
         verify(predictor).verify(any(), any(double[][].class));
 
         verifyNoMoreInteractions(validator, client, predictor);

--- a/java/api/src/test/java/com/exadel/frs/core/trainservice/sdk/faces/service/FacesRestApiClientTest.java
+++ b/java/api/src/test/java/com/exadel/frs/core/trainservice/sdk/faces/service/FacesRestApiClientTest.java
@@ -63,10 +63,10 @@ class FacesRestApiClientTest {
         Integer faceLimit = 1;
         Double thresholdC = 1.0;
         String facePlugins = "plugins";
-        when(feignClient.findFaces(photo, faceLimit, thresholdC, facePlugins)).thenThrow(caughtClass);
+        when(feignClient.findFaces(photo, faceLimit, thresholdC, facePlugins, true)).thenThrow(caughtClass);
 
         // when
-        Executable action = () -> restApiClient.findFaces(photo, faceLimit, thresholdC, facePlugins);
+        Executable action = () -> restApiClient.findFaces(photo, faceLimit, thresholdC, facePlugins, true);
 
         // then
         assertThrows(thrownClass, action);
@@ -80,10 +80,10 @@ class FacesRestApiClientTest {
         Integer faceLimit = 1;
         Double thresholdC = 1.0;
         String facePlugins = "plugins";
-        when(feignClient.findFaces(photo, faceLimit, thresholdC, facePlugins)).thenReturn(expected);
+        when(feignClient.findFaces(photo, faceLimit, thresholdC, facePlugins, true)).thenReturn(expected);
 
         // when
-        FindFacesResponse actual = restApiClient.findFaces(photo, faceLimit, thresholdC, facePlugins);
+        FindFacesResponse actual = restApiClient.findFaces(photo, faceLimit, thresholdC, facePlugins, true);
 
         // then
         assertThat(actual, is(expected));
@@ -106,10 +106,10 @@ class FacesRestApiClientTest {
         MultipartFile photo = mock(MultipartFile.class);
         Integer faceLimit = 1;
         Double thresholdC = 1.0;
-        when(feignClient.findFaces(photo, faceLimit, thresholdC, outPlugins)).thenReturn(expected);
+        when(feignClient.findFaces(photo, faceLimit, thresholdC, outPlugins, true)).thenReturn(expected);
 
         // when
-        FindFacesResponse actual = restApiClient.findFacesWithCalculator(photo, faceLimit, thresholdC, inPlugins);
+        FindFacesResponse actual = restApiClient.findFacesWithCalculator(photo, faceLimit, thresholdC, inPlugins, true);
 
         // then
         assertThat(actual, is(expected));
@@ -122,10 +122,10 @@ class FacesRestApiClientTest {
         MultipartFile photo = mock(MultipartFile.class);
         Integer faceLimit = 1;
         Double thresholdC = 1.0;
-        when(feignClient.findFaces(photo, faceLimit, thresholdC, CALCULATOR_PLUGIN)).thenThrow(caughtClass);
+        when(feignClient.findFaces(photo, faceLimit, thresholdC, CALCULATOR_PLUGIN, true)).thenThrow(caughtClass);
 
         // when
-        Executable action = () -> restApiClient.findFacesWithCalculator(photo, faceLimit, thresholdC, null);
+        Executable action = () -> restApiClient.findFacesWithCalculator(photo, faceLimit, thresholdC, null, true);
 
         // then
         assertThrows(thrownClass, action);

--- a/java/api/src/test/java/com/exadel/frs/core/trainservice/service/SubjectServiceTest.java
+++ b/java/api/src/test/java/com/exadel/frs/core/trainservice/service/SubjectServiceTest.java
@@ -185,7 +185,7 @@ class SubjectServiceTest {
         var detProbThreshold = 0.7;
         MultipartFile file = new MockMultipartFile("anyname", new byte[]{0xA});
 
-        when(facesApiClient.findFacesWithCalculator(file, MAX_FACES_TO_RECOGNIZE, detProbThreshold, null))
+        when(facesApiClient.findFacesWithCalculator(file, MAX_FACES_TO_RECOGNIZE, detProbThreshold, null, true))
                 .thenReturn(findFacesResponse(1));
         when(euclideanDistanceClassifier.normalizeOne(any()))
                 .thenReturn(new double[]{1.1, 2.2});
@@ -203,7 +203,7 @@ class SubjectServiceTest {
         var detProbThreshold = 0.7;
         MultipartFile file = new MockMultipartFile("anyname", new byte[]{0xA});
 
-        when(facesApiClient.findFacesWithCalculator(file, MAX_FACES_TO_RECOGNIZE, detProbThreshold, null))
+        when(facesApiClient.findFacesWithCalculator(file, MAX_FACES_TO_RECOGNIZE, detProbThreshold, null, true))
                 .thenReturn(findFacesResponse(3));
 
         assertThatThrownBy(() ->
@@ -221,7 +221,7 @@ class SubjectServiceTest {
         var file = new MockMultipartFile("anyname", new byte[]{0xA});
         var embeddingCollection = mock(EmbeddingCollection.class);
 
-        when(facesApiClient.findFacesWithCalculator(any(), any(), any(), any()))
+        when(facesApiClient.findFacesWithCalculator(any(), any(), any(), any(), any()))
                 .thenReturn(findFacesResponse(2));
         when(embeddingCacheProvider.getOrLoad(API_KEY))
                 .thenReturn(embeddingCollection);
@@ -304,7 +304,7 @@ class SubjectServiceTest {
                 makeEnhancedEmbeddingProjection("A"),
                 makeEnhancedEmbeddingProjection("B")));
 
-        when(facesApiClient.findFacesWithCalculator(any(), any(), any(), any()))
+        when(facesApiClient.findFacesWithCalculator(any(), any(), any(), any(), any()))
                 .thenReturn(findFacesResponse(2));
         when(embeddingCacheProvider.getOrLoad(API_KEY))
                 .thenReturn(embeddingCollection);

--- a/java/common/src/main/java/com/exadel/frs/commonservice/sdk/faces/FacesApiClient.java
+++ b/java/common/src/main/java/com/exadel/frs/commonservice/sdk/faces/FacesApiClient.java
@@ -22,7 +22,8 @@ public interface FacesApiClient {
             MultipartFile photo,
             Integer faceLimit,
             Double thresholdC,
-            String facePlugins);
+            String facePlugins,
+            Boolean detectFaces);
 
     /**
      * Calls /find_faces_base64 endpoint of Faces API
@@ -37,7 +38,8 @@ public interface FacesApiClient {
             String imageAsBase64,
             Integer faceLimit,
             Double thresholdC,
-            String facePlugins);
+            String facePlugins,
+            Boolean detectFaces);
 
     /**
      * Calls /find_faces endpoint of Faces API with 'calculator' plugin always on
@@ -46,7 +48,8 @@ public interface FacesApiClient {
             MultipartFile photo,
             Integer faceLimit,
             Double thresholdC,
-            String facePlugins);
+            String facePlugins,
+            Boolean detectFaces);
 
     /**
      * Calls /find_faces endpoint of Faces API with 'calculator' plugin always on
@@ -55,7 +58,8 @@ public interface FacesApiClient {
             String imageAsBase64,
             Integer faceLimit,
             Double thresholdC,
-            String facePlugins);
+            String facePlugins,
+            Boolean detectFaces);
 
     /**
      * Calls /status endpoint of Faces API

--- a/java/common/src/main/java/com/exadel/frs/commonservice/sdk/faces/feign/FacesFeignClient.java
+++ b/java/common/src/main/java/com/exadel/frs/commonservice/sdk/faces/feign/FacesFeignClient.java
@@ -31,21 +31,28 @@ public interface FacesFeignClient {
     @Headers("Content-Type: multipart/form-data")
     FindFacesResponse findFaces(
             @Param(value = "file")
-                    MultipartFile photo,
+            MultipartFile photo,
             @Param(value = "limit")
-                    Integer faceLimit,
+            Integer faceLimit,
             @Param(value = "det_prob_threshold")
-                    Double thresholdC,
+            Double thresholdC,
             @Param(value = "face_plugins")
-                    String facePlugins);
+            String facePlugins,
+            @Param(value = "detect_faces")
+            Boolean detectFaces);
 
-    @RequestLine("POST /find_faces_base64?limit={limit}&det_prob_threshold={threshold}&face_plugins={plugins}")
+    @RequestLine("POST /find_faces_base64?limit={limit}&det_prob_threshold={threshold}&face_plugins={plugins}&detect_faces={detect_faces}")
     @Headers("Content-Type: " + MediaType.APPLICATION_JSON_VALUE)
     FindFacesResponse findFacesBase64(
             FindFacesRequest request,
-            @Param(value = "limit") Integer faceLimit,
-            @Param(value = "threshold") Double thresholdC,
-            @Param(value = "plugins") String facePlugins);
+            @Param(value = "limit")
+            Integer faceLimit,
+            @Param(value = "threshold")
+            Double thresholdC,
+            @Param(value = "plugins")
+            String facePlugins,
+            @Param(value = "detect_faces")
+            Boolean detectFaces);
 
     @RequestLine("GET /status")
     @Headers("Content-Type: multipart/form-data")

--- a/java/common/src/main/java/com/exadel/frs/commonservice/sdk/faces/service/FacesRestApiClient.java
+++ b/java/common/src/main/java/com/exadel/frs/commonservice/sdk/faces/service/FacesRestApiClient.java
@@ -24,10 +24,9 @@ public class FacesRestApiClient implements FacesApiClient {
     private final FacesFeignClient feignClient;
 
     @Override
-    public FindFacesResponse findFaces(final MultipartFile photo, final Integer faceLimit, final Double thresholdC,
-                                       final String facePlugins) {
+    public FindFacesResponse findFaces(final MultipartFile photo, final Integer faceLimit, final Double thresholdC, final String facePlugins, final Boolean detectFaces) {
         try {
-            return feignClient.findFaces(photo, faceLimit, thresholdC, facePlugins);
+            return feignClient.findFaces(photo, faceLimit, thresholdC, facePlugins, detectFaces);
         } catch (FeignException.BadRequest ex) {
             throw new NoFacesFoundException();
         } catch (FeignException e) {
@@ -36,13 +35,14 @@ public class FacesRestApiClient implements FacesApiClient {
     }
 
     @Override
-    public FindFacesResponse findFacesBase64(String imageAsBase64, Integer faceLimit, Double thresholdC, String facePlugins) {
+    public FindFacesResponse findFacesBase64(final String imageAsBase64, final Integer faceLimit, final Double thresholdC, final String facePlugins, final Boolean detectFaces) {
         try {
             return feignClient.findFacesBase64(
                     new FindFacesRequest(imageAsBase64),
                     faceLimit,
                     thresholdC,
-                    facePlugins
+                    facePlugins,
+                    detectFaces
             );
         } catch (FeignException.BadRequest ex) {
             throw new NoFacesFoundException();
@@ -52,17 +52,16 @@ public class FacesRestApiClient implements FacesApiClient {
     }
 
     @Override
-    public FindFacesResponse findFacesWithCalculator(final MultipartFile photo, final Integer faceLimit, final Double thresholdC,
-                                                     final String facePlugins) {
-        return findWithCalculator(photo, null, faceLimit, thresholdC, facePlugins);
+    public FindFacesResponse findFacesWithCalculator(final MultipartFile photo, final Integer faceLimit, final Double thresholdC, final String facePlugins, final Boolean detectFaces) {
+        return findWithCalculator(photo, null, faceLimit, thresholdC, facePlugins, detectFaces);
     }
 
     @Override
-    public FindFacesResponse findFacesBase64WithCalculator(String imageAsBase64, Integer faceLimit, Double thresholdC, String facePlugins) {
-        return findWithCalculator(null, imageAsBase64, faceLimit, thresholdC, facePlugins);
+    public FindFacesResponse findFacesBase64WithCalculator(final String imageAsBase64, final Integer faceLimit, final Double thresholdC, final String facePlugins, final Boolean detectFaces) {
+        return findWithCalculator(null, imageAsBase64, faceLimit, thresholdC, facePlugins, detectFaces);
     }
 
-    private FindFacesResponse findWithCalculator(final MultipartFile photo, final String imageAsBase64, Integer faceLimit, Double thresholdC, String facePlugins) {
+    private FindFacesResponse findWithCalculator(final MultipartFile photo, final String imageAsBase64, final Integer faceLimit, final Double thresholdC, final String facePlugins, final Boolean detectFaces) {
         try {
             String finalFacePlugins;
             if (StringUtils.isNotBlank(facePlugins)) {
@@ -76,13 +75,14 @@ public class FacesRestApiClient implements FacesApiClient {
             }
 
             if (photo != null) {
-                return feignClient.findFaces(photo, faceLimit, thresholdC, finalFacePlugins);
+                return feignClient.findFaces(photo, faceLimit, thresholdC, finalFacePlugins, detectFaces);
             } else {
                 return feignClient.findFacesBase64(
                         new FindFacesRequest(imageAsBase64),
                         faceLimit,
                         thresholdC,
-                        finalFacePlugins
+                        finalFacePlugins,
+                        detectFaces
                 );
             }
         } catch (FeignException.BadRequest ex) {


### PR DESCRIPTION
To skip face detection step you need to add additional parameter to request:
- detect_faces=false
if detect_faces=true, flow will work in old way with face detection step
if detect_faces=false, flow will work with skipping face detection step (we can upload only face without background)

Will skip PoseEstimator and MaskDetector.
Working for facenet and insightface flow.

Also cherry-pick Java part (1 commit)

Was tested manually and by rebuilding docker image with running tests