### PR TITLE
Add ARM64 support

### DIFF
--- a/embedding-calculator/Dockerfile
+++ b/embedding-calculator/Dockerfile
@@ -4,12 +4,45 @@ FROM ${BASE_IMAGE:-python:3.7-slim}
 RUN apt-get update && apt-get install -y build-essential cmake git wget unzip \
         curl yasm pkg-config libswscale-dev libtbb2 libtbb-dev libjpeg-dev \
         libpng-dev libtiff-dev libavformat-dev libpq-dev libfreeimage3 python3-opencv \
+        libaec-dev libblosc-dev libbrotli-dev libbz2-dev libgif-dev libopenjp2-7-dev \
+        liblcms2-dev libcharls-dev libjxr-dev liblz4-dev libcfitsio-dev libsnappy-dev \
+        libwebp-dev libzopfli-dev libzstd-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# Dependencies for imagecodecs
+WORKDIR /tmp
+
+# brunsli
+RUN git clone --depth=1 --shallow-submodules --recursive -b v0.1 https://github.com/google/brunsli && \
+	cd brunsli && \
+	cmake -DCMAKE_BUILD_TYPE=Release . && \
+	make -j$(nproc) install && \
+	rm -rf /tmp/brunsli
+
+# libjxl
+RUN git clone --depth=1 --shallow-submodules --recursive -b v0.7.0 https://github.com/libjxl/libjxl && \
+	cd libjxl && \
+	cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF . && \
+	make -j$(nproc) install && \
+	rm -rf /tmp/libjxl
+
+# zfp
+RUN git clone --depth=1 -b 0.5.5 https://github.com/LLNL/zfp && \
+	cd zfp && \
+	mkdir build && \
+	cd build && \
+	cmake -DCMAKE_BUILD_TYPE=Release .. && \
+	make -j$(nproc) install && \
+	rm -rf /tmp/zfp
+# End imagecodecs dependencies
 
 # install common python packages
 SHELL ["/bin/bash", "-c"]
 WORKDIR /app/ml
 COPY requirements.txt .
+# Ensure numpy is installed first as imagecodecs doesn't declare dependencies correctly until 2022.9.26,
+# which is not compatible with Python 3.7
+RUN pip --no-cache-dir install $(grep ^numpy requirements.txt)
 RUN pip --no-cache-dir install -r requirements.txt
 
 ARG BE_VERSION

--- a/embedding-calculator/requirements.txt
+++ b/embedding-calculator/requirements.txt
@@ -18,7 +18,7 @@ pylama~=7.7.1
 
 # dependencies for both scanner backends
 Pillow~=9.2.0
-imagecodecs~=2020.5.30
+imagecodecs~=2021.11.20
 numpy~=1.21
 scipy~=1.5.4
 opencv-python~=4.5.0

--- a/embedding-calculator/requirements.txt
+++ b/embedding-calculator/requirements.txt
@@ -21,9 +21,9 @@ Pillow~=9.2.0
 imagecodecs~=2020.5.30
 numpy~=1.21
 scipy~=1.5.4
-opencv-python~=4.4.0
-scikit-learn~=0.23.2
-scikit-image~=0.17.2
+opencv-python~=4.5.0
+scikit-learn~=0.24.2
+scikit-image~=0.18.3
 joblib~=1.2.0
 
 # web server

--- a/embedding-calculator/src/services/facescan/plugins/agegender/__init__.py
+++ b/embedding-calculator/src/services/facescan/plugins/agegender/__init__.py
@@ -12,4 +12,4 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 
-requirements = ('tensorflow~=2.1.4', 'tf-slim~=1.1.0')
+requirements = ('tensorflow~=2.11.0', 'tf-slim~=1.1.0')

--- a/embedding-calculator/src/services/facescan/plugins/dependencies.py
+++ b/embedding-calculator/src/services/facescan/plugins/dependencies.py
@@ -18,7 +18,7 @@ from src.constants import ENV
 from src.services.utils.pyutils import get_env
 
 
-def get_tensorflow(version='2.1.4') -> Tuple[str, ...]:
+def get_tensorflow(version='2.11.0') -> Tuple[str, ...]:
     libs = [f'tensorflow=={version}']
     cuda_version = get_env('CUDA', '').replace('.', '')
     if ENV.GPU_IDX > -1 and cuda_version:

--- a/embedding-calculator/src/services/facescan/plugins/facenet/__init__.py
+++ b/embedding-calculator/src/services/facescan/plugins/facenet/__init__.py
@@ -14,4 +14,4 @@
 
 from src.services.facescan.plugins.dependencies import get_tensorflow
 
-requirements = ('protobuf~=3.20.1',) + get_tensorflow() # + ('mtcnn~=0.1.0',)
+requirements = ('protobuf~=3.19.6',) + get_tensorflow() # + ('mtcnn~=0.1.0',)


### PR DESCRIPTION
This upgrades libraries to versions that have arm64 wheels available, and builds the remaining ones (imagecodecs) from source. I've only build-tested this as I currently don't have a spare arm64 device to test on, but the test suite passed:
```
#22 120.0 ==== 39 passed, 1 skipped, 45 deselected, 18 warnings in 101.35s (0:01:41) =====
```

If anyone wants to test this, you can build the images natively with `make` from the embedding-calculator folder. Or cross-build and export the image using:
```
docker buildx build -t compreface-core:arm64 --platform linux/arm64 --progress plain .
docker image save -o compreface-core-arm64.tar compreface-core:arm64
```

And import with:
```
docker image load -i compreface-core-arm64.tar
```

Fixes #610, possibly also #519 (I haven't tested building the CUDA images yet).

Marking as draft for now, as I still need to update the Makefile to use buildkit and try building the CUDA images. I'll also look at building imagecodecs in a separate container to reduce the final image size.