### PR TITLE
EFRS-1357 Update nginx ssl config with templates

### DIFF
--- a/dev/docker-compose.env.yml
+++ b/dev/docker-compose.env.yml
@@ -15,9 +15,10 @@ volumes:
 services:
   compreface-fe:
     volumes:
-      - ./nginx/conf.d:/etc/nginx/conf.d:ro
-      - /etc/letsencrypt/archive/$HOSTNAME/fullchain1.pem:/etc/nginx/ssl/fullchain.pem:ro
-      - /etc/letsencrypt/archive/$HOSTNAME/privkey1.pem:/etc/nginx/ssl/privkey.pem:ro
+      - ./nginx/templates:/etc/nginx/templates:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+    environment:
+      - NGINX_HOST=$HOSTNAME
     ports:
       - "8000:80"
       - "443:443"

--- a/dev/nginx/templates/nginx.conf.template
+++ b/dev/nginx/templates/nginx.conf.template
@@ -19,8 +19,8 @@ server {
 server {
     listen 443 ssl;
     server_name ui;
-    ssl_certificate /etc/nginx/ssl/fullchain.pem;
-    ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/$NGINX_HOST/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$NGINX_HOST/privkey.pem;
 
     client_max_body_size 10M;
 


### PR DESCRIPTION
The name of the new SSL certificate may change after the upgrade.
To take this into account and pass the hostname to the certificate path, we use the nginx configuration templating capabilities.