### PR TITLE
Close the JDWP debug port by default

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     container_name: "compreface-admin"
     ports:
       - "8081:8080"
-      - "5006:5005"
+      # - "5006:5005" # Uncomment this port mapping for application debug
     environment:
       - POSTGRES_USER=${postgres_username}
       - POSTGRES_PASSWORD=${postgres_password}
@@ -59,7 +59,7 @@ services:
     container_name: "compreface-api"
     ports:
       - "8082:8080"
-      - "5005:5005"
+      # - "5005:5005" # Uncomment this port mapping for application debug
     depends_on:
       - compreface-postgres-db
     environment:


### PR DESCRIPTION
You can open the JDWP port in case of debugging by uncomment the appropriate port mapping line and re-run a docker compose.