### PR TITLE
Update Rest-API-description.md

### DIFF
--- a/docs/Rest-API-description.md
+++ b/docs/Rest-API-description.md
@@ -351,10 +351,17 @@ curl -X POST "http://localhost:8000/api/v1/recognition/faces/delete" \
   
 Response body on success:
 ``` 
-{
-  "image_id": <image_id>,
-  "subject": <subject>
+[ {
+  "image_id" : "<image_id1>",
+  "subject" : "<subject>"
+}, {
+  "image_id" : "<image_id2>",
+  "subject" : "<subject>"
 }
+..., {
+  "image_id" : "<image_idN>",
+  "subject" : "<subjectN>"
+} ]
 ``` 
 
 | Element         | Description                                               | Type   | 


### PR DESCRIPTION
Reason: When using delete multiple, the returned data is a list, not an object.